### PR TITLE
fix(search): stop filter refresh loop

### DIFF
--- a/src/screens/SearchTab.jsx
+++ b/src/screens/SearchTab.jsx
@@ -152,14 +152,14 @@ export default function SearchTab() {
       ]);
       if (!statsErr && fresh) {
         setStats(normalizeStats(fresh));
-        for (const f of (freshFilters || filters)) clearPollError(f.id);
+        for (const f of (freshFilters || [])) clearPollError(f.id);
       }
       if (!filtErr && freshFilters) setFilters(freshFilters);
     }
     refresh();
     const interval = setInterval(refresh, 30000);
     return () => clearInterval(interval);
-  }, [setStats, setFilters, filters, clearPollError]);
+  }, [setStats, setFilters, clearPollError]);
 
   // ── Filter actions ─────────────────────────────────────────────
   const handleAddFilter = useCallback(async (webUrl, name) => {


### PR DESCRIPTION
## Summary

- Stop the Suchen refresh effect from depending on the state it replaces.
- Keep poll-error cleanup based on the freshly fetched filters.

## Root cause

The effect depended on `filters` and unconditionally stored the fresh SQLite result. Because each database query returns a new array, every update retriggered the effect immediately, causing repeated IPC/SQLite reads and renderer re-renders instead of waiting 30 seconds.

## Validation

- `npm run build`
- `npm run test:i18n`
- `npm run test:unit`
