### PR TITLE
fix(ui): stop showing generic error text under sent listings

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -455,6 +455,14 @@
       "title": "Wiederholung konnte nicht eingereiht werden",
       "message": "Homelander konnte diesen Eintrag nicht zur Wiederholung einreihen."
     },
+    "sent": {
+      "title": "Kontaktanfrage gesendet",
+      "message": "IS24 hat die Kontaktanfrage für dieses Inserat bestätigt."
+    },
+    "dryRun": {
+      "title": "Testlauf",
+      "message": "Der Testmodus ist aktiv — Homelander hat diese Bewerbung vorbereitet, aber nicht gesendet."
+    },
     "generic": {
       "title": "Etwas ist schiefgelaufen",
       "message": "Homelander konnte diese Aktion nicht abschließen. Details wurden protokolliert."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -455,6 +455,14 @@
       "title": "Could not queue retry",
       "message": "Homelander could not queue this listing for retry."
     },
+    "sent": {
+      "title": "Contact request sent",
+      "message": "IS24 confirmed the contact request for this listing."
+    },
+    "dryRun": {
+      "title": "Dry run",
+      "message": "Dry run mode is on, so Homelander prepared this application without sending it."
+    },
     "generic": {
       "title": "Something went wrong",
       "message": "Homelander could not complete that action. Details were logged."

--- a/src/shared/userErrors.js
+++ b/src/shared/userErrors.js
@@ -4,6 +4,18 @@
 // otherwise falls back to English KNOWN map.
 
 const KNOWN = {
+  // Not failures — the daemon stores an outcome detail on success too, and every
+  // detail string is routed through here. Without these, successes classify as GENERIC.
+  SENT: {
+    title: 'Contact request sent',
+    message: 'IS24 confirmed the contact request for this listing.',
+    action: 'No action needed',
+  },
+  DRY_RUN: {
+    title: 'Dry run',
+    message: 'Dry run mode is on, so Homelander prepared this application without sending it.',
+    action: 'No action needed',
+  },
   BACKEND_UNAVAILABLE: {
     title: 'Backend unavailable',
     message: 'Homelander is still starting up. Try again in a moment.',
@@ -121,6 +133,11 @@ function tError(t, code, field) {
   return null;
 }
 
+// SENT/DRY_RUN are outcomes, not failures — callers styling by severity must not paint them red.
+function defaultSeverity(code) {
+  return code === 'SENT' || code === 'DRY_RUN' ? 'info' : 'error';
+}
+
 export function createSupportId(prefix = 'HML') {
   try {
     const bytes = new Uint8Array(4);
@@ -138,6 +155,11 @@ export function classifyError(input, context = {}) {
 
   const operation = context.operation || '';
   const raw = rawErrorText(input).toLowerCase();
+
+  // Success details first — they never carry an operation hint and would otherwise fall to GENERIC.
+  // Sources: is24-contactor 'confirmed (modal)' / 'confirmed (success text)', daemon 'modal ✓'.
+  if (/^confirmed\b/.test(raw) || raw.startsWith('modal ✓')) return 'SENT';
+  if (raw.startsWith('dry run')) return 'DRY_RUN';
 
   if (operation.includes('chrome') || operation.includes('browser')) {
     if (raw.includes('not responding') || raw.includes('target closed') || raw.includes('websocket') || raw.includes('cdp')) return 'BROWSER_NOT_RESPONDING';
@@ -201,7 +223,7 @@ export function toUserError(input, context = {}, t) {
   const code = classifyError(input, context);
   const base = KNOWN[code] || KNOWN.GENERIC;
   return {
-    severity: context.severity || 'error',
+    severity: context.severity || defaultSeverity(code),
     code,
     title: tError(t, code, 'title') || base.title,
     message: tError(t, code, 'message') || base.message,


### PR DESCRIPTION
## Summary

Listings with a **Gesendet** / Sent badge also rendered the generic failure text under them:

> Homelander konnte diese Aktion nicht abschließen. Details wurden protokolliert.

Cause: the listing `detail` string is routed through `userErrorText()` regardless of outcome (`src/components/ActivityFeed.jsx:200`, `src/screens/HistoryTab.jsx:122`). The success details the daemon stores — `confirmed (modal)` / `confirmed (success text)` (`engine/is24-contactor.js:1435`, `:1518`) and `modal ✓` (`engine/daemon.js:326`) — match no pattern in `classifyError()`, so they fell through to `GENERIC`. `DRY_RUN` entries (`dry run — not sent`, `engine/daemon.js:309`) hit the same path.

Purely cosmetic — the sends did succeed; the UI was running success strings through an error classifier that had no success branch.

## Fix

Handled in the classifier rather than at each call site, so `ActivityFeed` and `HistoryTab` (and any future surface) are correct without needing to know the outcome:

- `KNOWN.SENT` and `KNOWN.DRY_RUN` codes, matched at the top of `classifyError()` before the operation routing
- `defaultSeverity(code)` so these resolve to `info` instead of the previously hardcoded `error`
- `errors.sent` / `errors.dryRun` strings in `de.json` and `en.json`

Real failures are unchanged — `SUBMIT_UNCONFIRMED`, `PREMIUM_ONLY`, `CAPTCHA_REQUIRED` and `GENERIC` all still classify as before.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Docs / repo polish
- [ ] Refactor

## Checklist

- [x] Tests pass (`npm test`) — 281 passing
- [x] i18n keys in sync (`npm run test:i18n`)
- [ ] Relevant docs updated — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)